### PR TITLE
Add HSKFoodTracker addon

### DIFF
--- a/repos
+++ b/repos
@@ -38,3 +38,4 @@ https://github.com/TabbyMackerel/RatkinRaceHSK-Expended
 https://github.com/kasirii/VanillaStorytellersExpanded-WinstonWave-HSK
 https://github.com/Elldar112/Eccentric-Tech-Series-HSK
 https://github.com/Elldar112/Neolithic-Fortifications-HSK
+https://github.com/linyaDev/HSKFoodTracker


### PR DESCRIPTION
Add HSKFoodTracker to the addons list.

Food supply widget — shows how many days of food remain. Calculates per-pawn consumption (genes, traits, race). Click for detailed breakdown.

https://github.com/linyaDev/HSKFoodTracker