### PR TITLE
Add CEQuickLoadout addon

### DIFF
--- a/repos
+++ b/repos
@@ -41,6 +41,7 @@ https://github.com/TabbyMackerel/RatkinRaceHSK-Expended
 https://github.com/kasirii/VanillaStorytellersExpanded-WinstonWave-HSK
 https://github.com/linyaDev/HSKFoodTracker
 https://github.com/linyaDev/HSKDietTracker
+https://github.com/linyaDev/CEQuickLoadout
 https://github.com/carbineact1on/HSK-Mod-Fixes-Pack
 https://github.com/carbineact1on/HSK-VFE-Collection
 https://github.com/carbineact1on/HSK-RH2-Collection


### PR DESCRIPTION
## Summary
- Add CEQuickLoadout to addons list
- Right-click items on the map to manage CE loadouts without opening the CE manager
- Add items to colonist loadouts or create new ones
- Supports CE Extended Loadout (PersonalLoadout)

Repository: https://github.com/linyaDev/CEQuickLoadout