### PR TITLE
Add HSK-Race-Collection and HSK-VQE-Collection repository links

### DIFF
--- a/repos
+++ b/repos
@@ -45,3 +45,5 @@ https://github.com/linyaDev/CEQuickLoadout
 https://github.com/carbineact1on/HSK-Mod-Fixes-Pack
 https://github.com/carbineact1on/HSK-VFE-Collection
 https://github.com/carbineact1on/HSK-RH2-Collection
+https://github.com/carbineact1on/HSK-Race-Collection
+https://github.com/carbineact1on/HSK-VQE-Collection


### PR DESCRIPTION
Adds two new collection-format repos to the addons launcher list:

- **HSK-Race-Collection** — HSK/CE-patched custom race mods (Wolfein Race)
- **HSK-VQE-Collection** — HSK/CE-patched compatibility patches for the Vanilla Quests Expanded mod series (currently includes HSK-VQE-Deadlife)
