### PR TITLE
Add HSKFaith addon

### DIFF
--- a/repos
+++ b/repos
@@ -42,6 +42,7 @@ https://github.com/kasirii/VanillaStorytellersExpanded-WinstonWave-HSK
 https://github.com/linyaDev/HSKFoodTracker
 https://github.com/linyaDev/HSKDietTracker
 https://github.com/linyaDev/CEQuickLoadout
+https://github.com/linyaDev/HSKFaith
 https://github.com/carbineact1on/HSK-Mod-Fixes-Pack
 https://github.com/carbineact1on/HSK-VFE-Collection
 https://github.com/carbineact1on/HSK-RH2-Collection


### PR DESCRIPTION
Add HSKFaith to the addons list.

HSKFaith — Faith need with meme effects, per-meme bars, stat modifiers, meme categories.

https://github.com/linyaDev/HSKFaith